### PR TITLE
chore: fix ci release flow to correctly report notifications

### DIFF
--- a/.github/workflows/releaseWorkflow.yml
+++ b/.github/workflows/releaseWorkflow.yml
@@ -63,7 +63,6 @@ jobs:
     secrets:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  # ATTENTION: Choose this when you are building a service. Comment-out/Remove if not needed!
   publish_image:
     needs:
       - release_tag
@@ -76,29 +75,15 @@ jobs:
       USER: ${{ github.actor }}
       PASSWORD: ${{ secrets.GITHUB_TOKEN }}
 
-  # ATTENTION: Choose this when you are creating a NPM library
-#   Commentted out as this repo is no creating a NPM library
-#   publish_lib:
-#     needs:
-#       - release_tag
-#       - release_gh
-#     uses: modusbox/github-actions-node/.github/workflows/publishLibraryJob.yml@v0.0.2
-#     with:
-#       RELEASE_VERSION: v${{ needs.release_tag.outputs.VERSION }}
-#     secrets:
-#       NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   notify:
     needs:
       - release_tag
       - release_gh
-      # ATTENTION: Choose 'publish_image' or/and 'publish_lib' depending on the type of project. Comment-out/Remove if not needed!
       - publish_image
-#       - publish_lib
     if: ${{ always() }} # Here we report on the final state of the workflow!
     uses: modusbox/github-actions-node/.github/workflows/notifyReleaseJob.yml@v0.0.2
     with:
-      JOB_STATUS: ${{ ((needs.release_tag.result  == 'success') && (needs.release_gh.result  == 'success') && (needs.publish_image.result  == 'success') && (needs.publish_lib.result  == 'success')) && 'success' || 'failed' }}
+      JOB_STATUS: ${{ ((needs.release_tag.result  == 'success') && (needs.release_gh.result  == 'success') && (needs.publish_image.result  == 'success')) && 'success' || 'failed' }}
       TYPE: Release
       RELEASE_VERSION: ${{ ((needs.release_tag.result  == 'success') && (needs.release_gh.result  == 'success') && (needs.publish_image.result  == 'success') && (needs.publish_lib.result  == 'success')) && format('v{0}', needs.release_tag.outputs.VERSION) || 'n/a' }}
       RELEASE_URL: ${{ ((needs.release_tag.result  == 'success') && (needs.release_gh.result  == 'success') && (needs.publish_image.result  == 'success') && (needs.publish_lib.result  == 'success')) && format('{0} {1}/{2}/releases/tag/v{3}', ':shipit:', github.server_url, github.repository, needs.release_tag.outputs.VERSION) || ':fire:' }}


### PR DESCRIPTION
- cleaned up CI release flow by removing CI placeholders for publishing libs
- fixed status check for notifications that was still expected the publish libs job to run